### PR TITLE
fix: Ammend createOffline middleware typing

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -112,7 +112,7 @@ declare module '@redux-offline/redux-offline/lib/types' {
 }
 
 declare module '@redux-offline/redux-offline' {
-  import { createStore as createReduxStore, Store, StoreEnhancer, Dispatch, MiddlewareAPI } from 'redux';
+  import { createStore as createReduxStore, Store, StoreEnhancer, Dispatch, Middleware } from 'redux';
 
   import { Config } from '@redux-offline/redux-offline/lib/types';
 
@@ -130,6 +130,6 @@ declare module '@redux-offline/redux-offline' {
       preloadedState: T,
       enhancer: StoreEnhancer<T>,
     ) => Store<T>,
-    middleware: (api: MiddlewareAPI<any>) => (next: Dispatch<any>) => Dispatch<any>,
+    middleware: Middleware
   });
 }


### PR DESCRIPTION
Adjust `createOffline`'s middleware typing from custom implementation to consume Redux's own `Middleware` type

Fixes: #274 