### PR TITLE
Change dequeue to honor peek override

### DIFF
--- a/src/defaults/queue.js
+++ b/src/defaults/queue.js
@@ -5,8 +5,13 @@ function enqueue(array, item, context) {
 }
 
 function dequeue(array, item, context) {
-  const [, ...rest] = array;
-  return rest;
+  let index = array.indexOf(item.meta.offlineAction);
+  if (index >= 0)
+  {
+    let rest = array.slice();
+    rest.splice(index, 1);
+    return rest;
+  }
 }
 
 function peek(array, item, context) {


### PR DESCRIPTION
If you override peek and change the order in which you return items (see https://github.com/redux-offline/redux-offline/issues/326), you get a lot of weird behavior because dequeue always removes the first element. By having dequeue inspect which item was taken and actually removing that item, the default implementation allows for override of only peek.