### PR TITLE
Pass completed transaction id to the dequeue method

### DIFF
--- a/src/send.js
+++ b/src/send.js
@@ -33,7 +33,7 @@ const complete = (
   return (({
     ...action,
     payload: result.payload,
-    meta: { ...action.meta, success: result.success, completed: true }
+    meta: { ...action.meta, success: result.success, completed: true, transaction: offlineAction.meta.transaction }
   }: any): ResultAction);
 };
 


### PR DESCRIPTION
It's possible to override the peek function to prioritise actions in the queue. The default dequeue assumes that the next completed action will be the first in the queue and remove it despite it not being the completed action. By passing the transaction ID the dequeue can remove the completed action.

dequeue(offlineActions, action, context) {
	// Remove an offline action when it has been successfully resolved or discarded.
	return offlineActions.filter((i) => i.meta.transaction !== action.meta.transaction);
}