### PR TITLE
Import NetInfo from the react-native-community repo

### DIFF
--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -1,5 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
-import { AppState, NetInfo } from 'react-native'; // eslint-disable-line
+import { AppState } from 'react-native'; // eslint-disable-line
+import NetInfo from "@react-native-community/netinfo"; // eslint-disable-line
 import LegacyDetectNetwork from './detectNetwork.native.legacy';
 
 class DetectNetwork {

--- a/src/defaults/detectNetwork.native.legacy.js
+++ b/src/defaults/detectNetwork.native.legacy.js
@@ -1,5 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
-import { AppState, NetInfo } from 'react-native'; // eslint-disable-line
+import { AppState } from 'react-native'; // eslint-disable-line
+import NetInfo from "@react-native-community/netinfo"; // eslint-disable-line
 
 class LegacyDetectNetwork {
   constructor(callback) {


### PR DESCRIPTION
react-native extracted the NetInfo library which triggers an error when using the latest version of react-native.