### PR TITLE
fix: default-effect package tests

### DIFF
--- a/packages/default-effect/jest.config.js
+++ b/packages/default-effect/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testMatch: ['<rootDir>/src/**/__tests__/*.{ts,tsx,js,jsx}'],
+}

--- a/types.ts
+++ b/types.ts
@@ -12,7 +12,7 @@ export type UpdateState = (type: Updates, payload?: any) => void;
 
 export type Action<T = { [key: string]: any }, C = {}, R = {}> = T & {
   meta: {
-    effect: string;
+    effect: { url: string };
     commit: C;
     rollback: R;
     transaction?: number;


### PR DESCRIPTION
Fix default effect package tests by making them comply with TS rules or by just skipping or casting type checks when not possible to reproduce a real situation