### PR TITLE
Fix readme logo and add config to deploy docs on github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img alt="redux-offline" src="docs/logo.png" width="300"></img>
+  <img alt="redux-offline" src="docs/static/img/redux-offline.png" width="300"></img>
 </p>
 <p>
   <a title='License' href="https://raw.githubusercontent.com/redux-offline/redux-offline/master/LICENSE" height="18">

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'Redux Offline',
   tagline: 'Build Offline-First Apps for Web and React Native',
-  url: 'https://your-docusaurus-test-site.com',
+  url: 'https://redux-offline.github.io',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
Fix readme logo that was broken after adding the new dogs and add config to deploy docs on github pages