### PR TITLE
Update persist.native.js

### DIFF
--- a/src/defaults/persist.native.js
+++ b/src/defaults/persist.native.js
@@ -2,7 +2,7 @@
 // $FlowIgnore
 import { persistStore } from 'redux-persist';
 // $FlowIgnore
-import { AsyncStorage } from 'react-native'; // eslint-disable-line
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export default (store: any, options: {}, callback: any) =>
   // $FlowFixMe


### PR DESCRIPTION
import AsyncStorage from '@react-native-async-storage/async-storage';   instead import { AsyncStorage } from 'react-native'; . AsyncStorage is now independent, no longer in the react-native package. and it breaks applications that are updated higher than expo 36.